### PR TITLE
Open/Copy Remote Url for Github

### DIFF
--- a/autoload/oscommands.vim
+++ b/autoload/oscommands.vim
@@ -28,7 +28,7 @@ function! s:currentOS()
   return known_os
 endfunction
 
-function! oscommands#OpenCommand()
+function! oscommands#OpenCommand() abort
   let currentos = <SID>currentOS()
   if !exists("g:opencommand")
     let g:opencommand = s:opencommands[currentos]

--- a/autoload/oscommands.vim
+++ b/autoload/oscommands.vim
@@ -3,7 +3,7 @@ let s:windows = 'windows'
 let s:linux = 'linux'
 let s:opencommands = {'windows': 'cmd /c start', 'mac': 'open',
       \ 'linux': 'xdg-open'}
-let s:copycommands = {'windows': 'clip', 'mac': 'clip',
+let s:copycommands = {'windows': 'clip', 'mac': 'pbcopy',
       \ 'linux': 'xsel --clipboard --input'}
 
 " Thanks Chris Toomey
@@ -36,3 +36,13 @@ function! oscommands#OpenCommand() abort
 
   return g:opencommand
 endfunction
+
+function! oscommands#CopyCommand() abort
+  let currentos = <SID>currentOS()
+  if !exists("g:copycommand")
+    let g:copycommand = s:copycommands[currentos]
+  endif
+
+  return g:copycommand
+endfunction
+

--- a/autoload/oscommands.vim
+++ b/autoload/oscommands.vim
@@ -1,0 +1,38 @@
+let s:mac = 'mac'
+let s:windows = 'windows'
+let s:linux = 'linux'
+let s:opencommands = {'windows': 'cmd /c start', 'mac': 'open',
+      \ 'linux': 'xdg-open'}
+let s:copycommands = {'windows': 'clip', 'mac': 'clip',
+      \ 'linux': 'xsel --clipboard --input'}
+
+" Thanks Chris Toomey
+" https://github.com/christoomey/vim-system-copy
+function! s:currentOS()
+  if exists("g:currentos")
+    return g:currentos
+  endif
+
+  let os = substitute(system('uname'), '\n', '', '')
+  let known_os = 'unknown'
+  if has("gui_mac") || os ==? 'Darwin'
+    let known_os = s:mac
+  elseif has("gui_win32") || os =~? 'cygwin'
+    let known_os = s:windows
+  elseif os ==? 'Linux'
+    let known_os = s:linux
+  else
+    exe "normal \<Esc>"
+    throw "unknown OS: " . os
+  endif
+  return known_os
+endfunction
+
+function! oscommands#OpenCommand()
+  let currentos = <SID>currentOS()
+  if !exists("g:opencommand")
+    let g:opencommand = s:opencommands[currentos]
+  endif
+
+  return g:opencommand
+endfunction

--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -7,3 +7,42 @@ nnoremap <SID>  <SID>
 function! s:stripnewlines(str)
   return substitute(a:str, '\n', '', 'g')
 endfunction
+
+function! s:getcurrentline()
+  return <SID>stripnewlines(line('.'))
+endfunction
+
+function! s:getcurrentfilepath()
+  return <SID>stripnewlines(expand("%p:."))
+endfunction
+
+function! s:cleanupremoteurl(giturl)
+  let remoteurl =  substitute(a:giturl, '\.git', '', '')
+  return <SID>stripnewlines(remoteurl)
+endfunction
+
+function! s:getoriginurl()
+  if !exists("g:remote")
+    let g:remote = "origin"
+  endif
+
+  let execcmd = "git remote get-url " . g:remote
+  let remoteurl = system(execcmd)
+  return <SID>cleanupremoteurl(remoteurl)
+endfunction
+
+function! s:getcurrentbranch()
+  if !exists("g:branch")
+    let branch = system("git rev-parse --abbrev-ref HEAD")
+    let g:branch = <SID>stripnewlines(branch)
+  endif
+
+  return g:branch
+endfunction
+
+function! s:getremoteurl()
+  let fullremoteurl = <SID>getoriginurl() . '/blob/' .
+        \ <SID>getcurrentbranch() . '\#L' . <SID>getcurrentline()
+  return fullremoteurl
+endfunction
+

--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -12,7 +12,7 @@ function! s:getlines()
   if b:line1 ==# b:line2
     return b:line1
   else
-    return b:line1 . "-" . b:line2
+    return b:line1 . "-L" . b:line2
   endif
 endfunction
 
@@ -46,7 +46,7 @@ endfunction
 
 function! s:getremoteurl()
   let fullremoteurl = <SID>getoriginurl() . '/blob/' .
-        \ <SID>getcurrentbranch() . '\#L' . <SID>getlines()
+        \ <SID>getcurrentbranch() . '/' . <SID>getcurrentfilepath() . '\#L' . <SID>getlines()
   return fullremoteurl
 endfunction
 

--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -64,7 +64,14 @@ function! s:copyremoteurl(line1, line2)
   let b:line2 = a:line2
 
   silent! call system(oscommands#CopyCommand(), s:getremoteurl())
+  echo 'Copied url to Clipboard!'
 endfunction
 
 command! -range OpenRemoteUrl call s:openremoteurl(<line1>, <line2>)
 command! -range CopyRemoteUrl call s:copyremoteurl(<line1>, <line2>)
+
+nnoremap <Plug>OpenRemoteUrl :OpenRemoteUrl<CR>
+vnoremap <Plug>OpenRemoteUrl :OpenRemoteUrl<CR>
+
+nnoremap <Plug>CopyRemoteUrl :CopyRemoteUrl<CR>
+vnoremap <Plug>CopyRemoteUrl :CopyRemoteUrl<CR>

--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -46,14 +46,25 @@ endfunction
 
 function! s:getremoteurl()
   let fullremoteurl = <SID>getoriginurl() . '/blob/' .
-        \ <SID>getcurrentbranch() . '/' . <SID>getcurrentfilepath() . '\#L' . <SID>getlines()
+        \ <SID>getcurrentbranch() . '/' . <SID>getcurrentfilepath() .
+        \ '\#L' . <SID>getlines()
   return fullremoteurl
 endfunction
 
 function! s:openremoteurl(line1, line2)
   let b:line1 = a:line1
   let b:line2 = a:line2
-  silent! execute "!open " . s:getremoteurl() | redraw!
+
+  silent! execute  "!" . oscommands#OpenCommand() . " " . s:getremoteurl()
+        \ | redraw!
+endfunction
+
+function! s:copyremoteurl(line1, line2)
+  let b:line1 = a:line1
+  let b:line2 = a:line2
+
+  silent! call system(oscommands#CopyCommand(), s:getremoteurl())
 endfunction
 
 command! -range OpenRemoteUrl call s:openremoteurl(<line1>, <line2>)
+command! -range CopyRemoteUrl call s:copyremoteurl(<line1>, <line2>)

--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -8,8 +8,12 @@ function! s:stripnewlines(str)
   return substitute(a:str, '\n', '', 'g')
 endfunction
 
-function! s:getcurrentline()
-  return <SID>stripnewlines(line('.'))
+function! s:getlines()
+  if b:line1 ==# b:line2
+    return b:line1
+  else
+    return b:line1 . "-" . b:line2
+  endif
 endfunction
 
 function! s:getcurrentfilepath()
@@ -42,7 +46,14 @@ endfunction
 
 function! s:getremoteurl()
   let fullremoteurl = <SID>getoriginurl() . '/blob/' .
-        \ <SID>getcurrentbranch() . '\#L' . <SID>getcurrentline()
+        \ <SID>getcurrentbranch() . '\#L' . <SID>getlines()
   return fullremoteurl
 endfunction
 
+function! s:openremoteurl(line1, line2)
+  let b:line1 = a:line1
+  let b:line2 = a:line2
+  silent! execute "!open " . s:getremoteurl() | redraw!
+endfunction
+
+command! -range OpenRemoteUrl call s:openremoteurl(<line1>, <line2>)

--- a/t/git-remote-open.vim
+++ b/t/git-remote-open.vim
@@ -9,3 +9,26 @@ describe 's:stripnewlines'
   end
 end
 
+describe 's:getcurentline'
+  before
+    new
+    put! = "New line"
+  end
+
+  after
+    close!
+  end
+
+  it 'retrieves the current line and removes new lines from it'
+    normal! gg
+    Expect Call('s:getcurrentline') ==? '1'
+  end
+end
+
+describe 's:cleanupremoteurl'
+  it 'strips .git from provided url'
+    Expect Call('s:cleanupremoteurl', "http://remote-url.git\n") ==?
+          \ 'http://remote-url'
+  end
+end
+

--- a/t/git-remote-open.vim
+++ b/t/git-remote-open.vim
@@ -14,7 +14,7 @@ describe 's:getlines'
     let b:line1 = 1
     let b:line2 = 2
 
-    Expect Call('s:getlines') ==# '1-2'
+    Expect Call('s:getlines') ==# '1-L2'
   end
 
   it 'returns a line number if same'

--- a/t/git-remote-open.vim
+++ b/t/git-remote-open.vim
@@ -9,19 +9,19 @@ describe 's:stripnewlines'
   end
 end
 
-describe 's:getcurentline'
-  before
-    new
-    put! = "New line"
+describe 's:getlines'
+  it 'dashes the line numbers if different'
+    let b:line1 = 1
+    let b:line2 = 2
+
+    Expect Call('s:getlines') ==# '1-2'
   end
 
-  after
-    close!
-  end
+  it 'returns a line number if same'
+    let b:line1 = 2
+    let b:line2 = 2
 
-  it 'retrieves the current line and removes new lines from it'
-    normal! gg
-    Expect Call('s:getcurrentline') ==? '1'
+    Expect Call('s:getlines') ==# 2
   end
 end
 

--- a/t/oscommands.vim
+++ b/t/oscommands.vim
@@ -4,6 +4,6 @@ describe 'oscommands#OpenCommand'
   it 'returns the right open command for linux'
     let g:currentos = 'linux'
 
-    Expect oscommands#OpenCommand() ==? 'xdg-open'
+    Expect oscommands#OpenCommand() ==# 'xdg-open'
   end
 end

--- a/t/oscommands.vim
+++ b/t/oscommands.vim
@@ -1,0 +1,9 @@
+runtime! plugin/autoload/oscommands.vim
+
+describe 'oscommands#OpenCommand'
+  it 'returns the right open command for linux'
+    let g:currentos = 'linux'
+
+    Expect oscommands#OpenCommand() ==? 'xdg-open'
+  end
+end

--- a/t/oscommands.vim
+++ b/t/oscommands.vim
@@ -7,3 +7,11 @@ describe 'oscommands#OpenCommand'
     Expect oscommands#OpenCommand() ==# 'xdg-open'
   end
 end
+
+describe 'oscommands#CopyCommand'
+  it 'returns the right os copy command'
+    let g:currentos = 'linux'
+
+    Expect oscommands#CopyCommand() ==# 'xsel --clipboard --input'
+  end
+end


### PR DESCRIPTION
This allows users of windows, unix and mac os platforms copy/open urls on github without leaving vim.

The change addresses the need by:
* Adding necessary functions to obtain the remote url with the assumption the user uses git scm
* Adding functions to return the right copy/open commands based on platforms
* Adding user defined commands