### PR TITLE
Bitbucket Support

### DIFF
--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -1,3 +1,8 @@
+if exists('g:loaded_git_remote_open')
+  finish
+endif
+let g:loaded_git_remote_open = 1
+
 " Provide access to script functions
 function! SID()
   return maparg('<SID>', 'n')
@@ -66,11 +71,11 @@ endfunction
 
 function! s:getcommithead()
   let commit_head = system("git rev-parse HEAD")
-  return <SID>stripnewlines(getcommithead)
+  return <SID>stripnewlines(commit_head)
 endfunction
 
 function! s:github_full_remote_url(origin_url)
-  let fullremoteurl = origin_url . '/blob/' .
+  let fullremoteurl = a:origin_url . '/blob/' .
         \ <SID>getcurrentbranch() . '/' . <SID>getcurrentfilepath() .
         \ '\#L' . <SID>get_github_lines()
   return fullremoteurl
@@ -91,23 +96,24 @@ function! s:getremoteurl()
   elseif s:isbitbucket(origin_url)
     return <SID>bitbucket_full_remote_url(origin_url)
   else
-    throw 'Remote not supported'
+    execute 'normal \<Esc>'
+    throw 'Remote ' . origin_url . ' not supported'
   endif
 endfunction
 
-function! s:openremoteurl(line1, line2)
+function! s:openremoteurl(line1, line2) abort
   let b:line1 = a:line1
   let b:line2 = a:line2
-
-  silent! execute  "!" . oscommands#OpenCommand() . " " . s:getremoteurl()
-        \ | redraw!
+  silent! execute  "!" . oscommands#OpenCommand() . " " .
+        \ shellescape(s:getremoteurl()) | redraw!
 endfunction
 
-function! s:copyremoteurl(line1, line2)
+function! s:copyremoteurl(line1, line2) abort
   let b:line1 = a:line1
   let b:line2 = a:line2
+  let copy_command = substitute(s:getremoteurl(), '\', '', 'g')
 
-  silent! call system(oscommands#CopyCommand(), s:getremoteurl())
+  silent! call system(oscommands#CopyCommand(), copy_command)
   echo 'Copied url to Clipboard!'
 endfunction
 

--- a/t/git-remote-open.vim
+++ b/t/git-remote-open.vim
@@ -9,13 +9,13 @@ describe 's:stripnewlines'
   end
 end
 
-describe 's:getlines'
+describe 's:get_github_lines'
   context 'when numbers are different'
     it 'dashes the line numbers'
       let b:line1 = 1
       let b:line2 = 2
 
-      Expect Call('s:getlines') ==# '1-L2'
+      Expect Call('s:get_github_lines') ==# '1-L2'
     end
   end
 
@@ -24,7 +24,27 @@ describe 's:getlines'
       let b:line1 = 2
       let b:line2 = 2
 
-      Expect Call('s:getlines') ==# 2
+      Expect Call('s:get_github_lines') ==# 2
+    end
+  end
+end
+
+describe 's:get_bitbucket_lines'
+  context 'when numbers are different'
+    it 'dashes the line numbers'
+      let b:line1 = 1
+      let b:line2 = 2
+
+      Expect Call('s:get_bitbucket_lines') ==# '1:2'
+    end
+  end
+
+  context 'when numbers are the same'
+    it 'returns a line number'
+      let b:line1 = 2
+      let b:line2 = 2
+
+      Expect Call('s:get_bitbucket_lines') ==# 2
     end
   end
 end
@@ -36,3 +56,30 @@ describe 's:cleanupremoteurl'
   end
 end
 
+describe 's:isbitbucket'
+  context 'when bitbucket'
+    it 'returns true'
+      Expect Call('s:isbitbucket', 'https://bitbucket.org/jon/jon') to_be_true
+    end
+  end
+
+  context 'when github'
+    it 'returns false'
+      Expect Call('s:isbitbucket', 'https://github.com/jon/jon') to_be_false
+    end
+  end
+end
+
+describe 's:isgithub'
+  context 'when github'
+    it 'returns true'
+      Expect Call('s:isgithub', 'https://github.com/jon/jon') to_be_true
+    end
+  end
+
+  context 'when not github'
+    it 'returns false'
+      Expect Call('s:isgithub', 'https://bitbucket.org/jon/jon') to_be_false
+    end
+  end
+end


### PR DESCRIPTION
Opening remote urls for bitbucket is not yet supported. We need to add this support

This change addresses the need by:
- Adding predicate functions to detect if origin is either bitbucket or github and returning the appropriate urls