### PR TITLE
Add Default mappings

### DIFF
--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -17,7 +17,7 @@ function! s:get_github_lines()
   if b:line1 ==# b:line2
     return b:line1
   else
-    return b:line1 . "-L" . b:line2
+    return b:line1 . '-L' . b:line2
   endif
 endfunction
 
@@ -25,7 +25,7 @@ function! s:get_bitbucket_lines()
   if b:line1 ==# b:line2
     return b:line1
   else
-    return b:line1 . ":" . b:line2
+    return b:line1 . ':' . b:line2
   endif
 endfunction
 
@@ -43,26 +43,26 @@ function! s:cleanupremoteurl(giturl)
 endfunction
 
 function! s:getoriginurl()
-  if !exists("g:remote")
-    let g:remote = "origin"
+  if !exists('g:remote')
+    let g:remote = 'origin'
   endif
 
-  let execcmd = "git remote get-url " . g:remote
+  let execcmd = 'git remote get-url ' . g:remote
   let remoteurl = system(execcmd)
   return <SID>cleanupremoteurl(remoteurl)
 endfunction
 
 function! s:isgithub(remote_url)
-  return a:remote_url =~ "github"
+  return a:remote_url =~ 'github'
 endfunction
 
 function! s:isbitbucket(remote_url)
-  return a:remote_url =~ "bitbucket"
+  return a:remote_url =~ 'bitbucket'
 endfunction
 
 function! s:getcurrentbranch()
-  if !exists("g:branch")
-    let branch = system("git rev-parse --abbrev-ref HEAD")
+  if !exists('g:branch')
+    let branch = system('git rev-parse --abbrev-ref HEAD')
     let g:branch = <SID>stripnewlines(branch)
   endif
 
@@ -70,7 +70,7 @@ function! s:getcurrentbranch()
 endfunction
 
 function! s:getcommithead()
-  let commit_head = system("git rev-parse HEAD")
+  let commit_head = system('git rev-parse HEAD')
   return <SID>stripnewlines(commit_head)
 endfunction
 
@@ -104,7 +104,7 @@ endfunction
 function! s:openremoteurl(line1, line2) abort
   let b:line1 = a:line1
   let b:line2 = a:line2
-  silent! execute  "!" . oscommands#OpenCommand() . " " .
+  silent! execute  '!' . oscommands#OpenCommand() . ' ' .
         \ shellescape(s:getremoteurl()) | redraw!
 endfunction
 

--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -125,3 +125,19 @@ vnoremap <Plug>OpenRemoteUrl :OpenRemoteUrl<CR>
 
 nnoremap <Plug>CopyRemoteUrl :CopyRemoteUrl<CR>
 vnoremap <Plug>CopyRemoteUrl :CopyRemoteUrl<CR>
+
+if !hasmapto('<Plug>OpenRemoteUrl', 'n') || maparg('<leader>gto', 'n') ==# ''
+  nmap <leader>gto <Plug>OpenRemoteUrl
+endif
+
+if !hasmapto('<Plug>OpenRemoteUrl', 'v') || maparg('<leader>gto', 'v') ==# ''
+  vmap <leader>gto <Plug>OpenRemoteUrl
+endif
+
+if !hasmapto('<Plug>CopyRemoteUrl', 'n') || maparg('<leader>gtc', 'n') ==# ''
+  nmap <leader>gtc <Plug>CopyRemoteUrl
+endif
+
+if !hasmapto('<Plug>CopyRemoteUrl', 'v') || maparg('<leader>gtc', 'v') ==# ''
+  vmap <leader>gtc <Plug>CopyRemoteUrl
+endif

--- a/t/git-remote-open.vim
+++ b/t/git-remote-open.vim
@@ -83,3 +83,25 @@ describe 's:isgithub'
     end
   end
 end
+
+describe 'mappings'
+  context 'normal mode'
+    it 'has a default plug OpenRemoteUrl mapping'
+      Expect maparg('<leader>gto', 'n') ==# '<Plug>OpenRemoteUrl'
+    end
+
+    it 'has a default plug CopyRemoteUrl mapping'
+      Expect maparg('<leader>gtc', 'n') ==# '<Plug>CopyRemoteUrl'
+    end
+  end
+
+  context 'visual mode'
+    it 'has a default plug OpenRemoteUrl mapping'
+      Expect maparg('<leader>gto', 'v') ==# '<Plug>OpenRemoteUrl'
+    end
+
+    it 'has a default plug CopyRemoteUrl mapping'
+      Expect maparg('<leader>gtc', 'v') ==# '<Plug>CopyRemoteUrl'
+    end
+  end
+end


### PR DESCRIPTION
This sets up default mappings to the git-remote-open commands by:

- Adding normal and visual mode mappings via <Plug>
- Adding specs to validate mappings