### PR TITLE
Handle Non Git Repos

### DIFF
--- a/autoload/oscommands.vim
+++ b/autoload/oscommands.vim
@@ -8,7 +8,7 @@ let s:copycommands = {'windows': 'clip', 'mac': 'pbcopy',
 
 " Thanks Chris Toomey
 " https://github.com/christoomey/vim-system-copy
-function! s:currentOS()
+function! s:current_os()
   if exists("g:currentos")
     return g:currentos
   endif
@@ -28,8 +28,8 @@ function! s:currentOS()
   return known_os
 endfunction
 
-function! oscommands#OpenCommand() abort
-  let currentos = <SID>currentOS()
+function! oscommands#open_command() abort
+  let currentos = <SID>current_os()
   if !exists("g:opencommand")
     let g:opencommand = s:opencommands[currentos]
   endif
@@ -37,8 +37,8 @@ function! oscommands#OpenCommand() abort
   return g:opencommand
 endfunction
 
-function! oscommands#CopyCommand() abort
-  let currentos = <SID>currentOS()
+function! oscommands#copy_command() abort
+  let currentos = <SID>current_os()
   if !exists("g:copycommand")
     let g:copycommand = s:copycommands[currentos]
   endif

--- a/plugin/git-remote-open.vim
+++ b/plugin/git-remote-open.vim
@@ -9,7 +9,7 @@ function! SID()
 endfunction
 nnoremap <SID>  <SID>
 
-function! s:stripnewlines(str)
+function! s:strip_new_lines(str)
   return substitute(a:str, '\n', '', 'g')
 endfunction
 
@@ -29,24 +29,24 @@ function! s:get_bitbucket_lines()
   endif
 endfunction
 
-function! s:getcurrentfilepath()
-  return <SID>stripnewlines(expand('%p:.'))
+function! s:get_current_file_path()
+  return <SID>strip_new_lines(expand('%p:.'))
 endfunction
 
 function! s:get_current_filename()
-  return <SID>stripnewlines(expand('%:t'))
+  return <SID>strip_new_lines(expand('%:t'))
 endfunction
 
-function! s:cleanupremoteurl(giturl)
+function! s:clean_up_remote_url(giturl)
   let remoteurl =  substitute(a:giturl, '\.git', '', '')
-  return <SID>stripnewlines(remoteurl)
+  return <SID>strip_new_lines(remoteurl)
 endfunction
 
 function! s:is_git_repo(remote_url)
   return a:remote_url =~ 'github\|bitbucket'
 endfunction
 
-function! s:getoriginurl()
+function! s:get_origin_url()
   if !exists('g:remote')
     let g:remote = 'origin'
   endif
@@ -54,7 +54,7 @@ function! s:getoriginurl()
   let execcmd = 'git remote get-url ' . g:remote
   let remoteurl = system(execcmd)
   if <SID>is_git_repo(remoteurl)
-    return <SID>cleanupremoteurl(remoteurl)
+    return <SID>clean_up_remote_url(remoteurl)
   else
     execute 'normal \<Esc>'
     throw 'Error: Not a git repo. git-remote-open can only be used inside
@@ -62,48 +62,48 @@ function! s:getoriginurl()
   endif
 endfunction
 
-function! s:isgithub(remote_url)
+function! s:is_github(remote_url)
   return a:remote_url =~ 'github'
 endfunction
 
-function! s:isbitbucket(remote_url)
+function! s:is_bitbucket(remote_url)
   return a:remote_url =~ 'bitbucket'
 endfunction
 
-function! s:getcurrentbranch()
+function! s:get_current_branch()
   if !exists('g:branch')
     let branch = system('git rev-parse --abbrev-ref HEAD')
-    let g:branch = <SID>stripnewlines(branch)
+    let g:branch = <SID>strip_new_lines(branch)
   endif
 
   return g:branch
 endfunction
 
-function! s:getcommithead()
+function! s:get_commit_head()
   let commit_head = system('git rev-parse HEAD')
-  return <SID>stripnewlines(commit_head)
+  return <SID>strip_new_lines(commit_head)
 endfunction
 
 function! s:github_full_remote_url(origin_url)
   let fullremoteurl = a:origin_url . '/blob/' .
-        \ <SID>getcurrentbranch() . '/' . <SID>getcurrentfilepath() .
+        \ <SID>get_current_branch() . '/' . <SID>get_current_file_path() .
         \ '\#L' . <SID>get_github_lines()
   return fullremoteurl
 endfunction
 
 function! s:bitbucket_full_remote_url(origin_url)
-  let fullremoteurl = a:origin_url . '/src/' . <SID>getcommithead() .
-        \ '/' . <SID>getcurrentfilepath() . '?at=' . <SID>getcurrentbranch()
+  let fullremoteurl = a:origin_url . '/src/' . <SID>get_commit_head() .
+        \ '/' . <SID>get_current_file_path() . '?at=' . <SID>get_current_branch()
         \ . '\#' . <SID>get_current_filename() . '-' .
         \ <SID>get_bitbucket_lines()
   return fullremoteurl
 endfunction
 
-function! s:getremoteurl()
-  let origin_url = <SID>getoriginurl()
-  if s:isgithub(origin_url)
+function! s:get_remote_url()
+  let origin_url = <SID>get_origin_url()
+  if s:is_github(origin_url)
     return <SID>github_full_remote_url(origin_url)
-  elseif s:isbitbucket(origin_url)
+  elseif s:is_bitbucket(origin_url)
     return <SID>bitbucket_full_remote_url(origin_url)
   else
     execute 'normal \<Esc>'
@@ -117,7 +117,7 @@ endfunction
 
 function! s:process_command(command_ref)
   try
-    let remote_url = <SID>getremoteurl()
+    let remote_url = <SID>get_remote_url()
     call a:command_ref(remote_url)
   catch /^Error/
     call <SID>exit_plugin(v:exception)
@@ -125,30 +125,30 @@ function! s:process_command(command_ref)
 endfunction
 
 function! s:process_open_command(remote_url)
-  silent! execute  '!' . oscommands#OpenCommand() . ' ' .
+  silent! execute  '!' . oscommands#open_command() . ' ' .
         \ shellescape(a:remote_url) | redraw!
 endfunction
 
 function! s:process_copy_command(remote_url)
   let stripped_remote_url = substitute(a:remote_url, '\', '', 'g')
-  silent! call system(oscommands#CopyCommand(), stripped_remote_url)
+  silent! call system(oscommands#copy_command(), stripped_remote_url)
   echo 'Copied url to Clipboard!'
 endfunction
 
-function! s:openremoteurl(line1, line2) abort
+function! s:open_remote_url(line1, line2) abort
   let b:line1 = a:line1
   let b:line2 = a:line2
   call <SID>process_command(function("s:process_open_command"))
 endfunction
 
-function! s:copyremoteurl(line1, line2) abort
+function! s:copy_remote_url(line1, line2) abort
   let b:line1 = a:line1
   let b:line2 = a:line2
   call <SID>process_command(function("s:process_copy_command"))
 endfunction
 
-command! -range OpenRemoteUrl call s:openremoteurl(<line1>, <line2>)
-command! -range CopyRemoteUrl call s:copyremoteurl(<line1>, <line2>)
+command! -range OpenRemoteUrl call s:open_remote_url(<line1>, <line2>)
+command! -range CopyRemoteUrl call s:copy_remote_url(<line1>, <line2>)
 
 nnoremap <Plug>OpenRemoteUrl :OpenRemoteUrl<CR>
 vnoremap <Plug>OpenRemoteUrl :OpenRemoteUrl<CR>

--- a/t/git-remote-open.vim
+++ b/t/git-remote-open.vim
@@ -105,3 +105,23 @@ describe 'mappings'
     end
   end
 end
+
+describe 's:is_git_repo'
+  context 'when github repo'
+    it 'returns true'
+      Expect Call('s:is_git_repo', 'https://github.com') to_be_true
+    end
+  end
+
+  context 'when bitbucket repo'
+    it 'returns false'
+      Expect Call('s:is_git_repo', 'https://bitbucket.org') to_be_false
+    end
+  end
+
+  context 'when not git repo'
+    it 'returns false'
+      Expect Call('s:is_git_repo', 'Fatal') to_be_false
+    do
+  end
+end

--- a/t/git-remote-open.vim
+++ b/t/git-remote-open.vim
@@ -3,9 +3,9 @@ runtime! plugin/git-remote-open.vim
 " Be able to access script functions in test
 call vspec#hint({'sid': 'SID()'})
 
-describe 's:stripnewlines'
+describe 's:strip_new_lines'
   it 'strips new lines from any given string'
-    Expect Call('s:stripnewlines', "\nrandom text\n") ==? 'random text'
+    Expect Call('s:strip_new_lines', "\nrandom text\n") ==? 'random text'
   end
 end
 
@@ -49,37 +49,37 @@ describe 's:get_bitbucket_lines'
   end
 end
 
-describe 's:cleanupremoteurl'
+describe 's:clean_up_remote_url'
   it 'strips .git from provided url'
-    Expect Call('s:cleanupremoteurl', "http://remote-url.git\n") ==?
+    Expect Call('s:clean_up_remote_url', "http://remote-url.git\n") ==?
           \ 'http://remote-url'
   end
 end
 
-describe 's:isbitbucket'
+describe 's:is_bitbucket'
   context 'when bitbucket'
     it 'returns true'
-      Expect Call('s:isbitbucket', 'https://bitbucket.org/jon/jon') to_be_true
+      Expect Call('s:is_bitbucket', 'https://bitbucket.org/jon/jon') to_be_true
     end
   end
 
   context 'when github'
     it 'returns false'
-      Expect Call('s:isbitbucket', 'https://github.com/jon/jon') to_be_false
+      Expect Call('s:is_bitbucket', 'https://github.com/jon/jon') to_be_false
     end
   end
 end
 
-describe 's:isgithub'
+describe 's:is_github'
   context 'when github'
     it 'returns true'
-      Expect Call('s:isgithub', 'https://github.com/jon/jon') to_be_true
+      Expect Call('s:is_github', 'https://github.com/jon/jon') to_be_true
     end
   end
 
   context 'when not github'
     it 'returns false'
-      Expect Call('s:isgithub', 'https://bitbucket.org/jon/jon') to_be_false
+      Expect Call('s:is_github', 'https://bitbucket.org/jon/jon') to_be_false
     end
   end
 end
@@ -115,7 +115,7 @@ describe 's:is_git_repo'
 
   context 'when bitbucket repo'
     it 'returns false'
-      Expect Call('s:is_git_repo', 'https://bitbucket.org') to_be_false
+      Expect Call('s:is_git_repo', 'https://bitbucket.org') to_be_true
     end
   end
 

--- a/t/oscommands.vim
+++ b/t/oscommands.vim
@@ -1,17 +1,17 @@
 runtime! plugin/autoload/oscommands.vim
 
-describe 'oscommands#OpenCommand'
+describe 'oscommands#open_command'
   it 'returns the right open command for linux'
     let g:currentos = 'linux'
 
-    Expect oscommands#OpenCommand() ==# 'xdg-open'
+    Expect oscommands#open_command() ==# 'xdg-open'
   end
 end
 
-describe 'oscommands#CopyCommand'
+describe 'oscommands#copy_command'
   it 'returns the right os copy command'
     let g:currentos = 'linux'
 
-    Expect oscommands#CopyCommand() ==# 'xsel --clipboard --input'
+    Expect oscommands#copy_command() ==# 'xsel --clipboard --input'
   end
 end


### PR DESCRIPTION
When git-remote-open is used for non git repos, it throws an error which is visible to the user. The plugin should rather catch this error and provide proper handling for it.

This change addresses the need by:
- adding is_git_repo predicate method
- using try..catch to provide consistent error handling for all functions
- changing all function names to snake case[not related]